### PR TITLE
feat(rules): add karpathy rule for opinionated CLAUDE.md recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ Validates Claude Code hook configuration (`.claude/settings.json`).
 - **Severity**: Error for JSON/structure issues, Warning for dangerous commands
 - **Enabled**: By default
 
+### Karpathy Recommendations (`karpathy`) 🆕
+
+Opinionated CLAUDE.md style advisories inspired by Andrej Karpathy's commentary on writing for LLMs and "context engineering" — you program the model in English, so the context window should be minimal, high signal-to-noise, literal, and example-driven. Heuristics, not an official standard.
+
+- **Checks**:
+  - Hedging language (`try to`, `where appropriate`) that makes instructions non-literal
+  - Filler / politeness (`please`, `thank you`, `you are a helpful assistant`) that spends context without signal
+  - Guideline sections that list many rules but show no concrete example (show, don't tell)
+  - Overly long prose paragraphs (prefer tight, skimmable lines or bullets)
+- **Scope**: `CLAUDE.md` files only; code fences are ignored
+- **Severity**: Info (recommendations, never fails CI)
+- **Enabled**: By default
+
 ### File Size Rule (`file-size`)
 
 Validates that CLAUDE.md files don't exceed size limits for optimal performance.

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -14,6 +14,7 @@ import { CommandSafetyRule } from '../../rules/CommandSafetyRule.js';
 import { SkillStructureRule } from '../../rules/SkillStructureRule.js';
 import { SubagentStructureRule } from '../../rules/SubagentStructureRule.js';
 import { HookConfigurationRule } from '../../rules/HookConfigurationRule.js';
+import { KarpathyRule } from '../../rules/KarpathyRule.js';
 import { formatResult } from '../formatters/textFormatter.js';
 
 export const lintCommand = new Command('lint')
@@ -49,6 +50,8 @@ export const lintCommand = new Command('lint')
           new SkillStructureRule(),
           new SubagentStructureRule(),
           new HookConfigurationRule(),
+          // Opinionated CLAUDE.md recommendations (Karpathy-inspired, INFO)
+          new KarpathyRule(),
         ];
 
         const engine = new RulesEngine(rules);

--- a/src/cli/commands/lintEnhanced.ts
+++ b/src/cli/commands/lintEnhanced.ts
@@ -15,6 +15,7 @@ import { CommandSafetyRule } from '../../rules/CommandSafetyRule.js';
 import { SkillStructureRule } from '../../rules/SkillStructureRule.js';
 import { SubagentStructureRule } from '../../rules/SubagentStructureRule.js';
 import { HookConfigurationRule } from '../../rules/HookConfigurationRule.js';
+import { KarpathyRule } from '../../rules/KarpathyRule.js';
 import { formatResult } from '../formatters/textFormatter.js';
 import { ConfigLoader } from '../../infrastructure/ConfigLoader.js';
 import { AutoFixer } from '../../infrastructure/AutoFixer.js';
@@ -180,6 +181,9 @@ export const lintEnhancedCommand = new Command('lint')
         if (config.rules['hook-configuration']?.enabled !== false) {
           const hookOptions = config.rules['hook-configuration']?.options ?? {};
           rules.push(new HookConfigurationRule(hookOptions));
+        }
+        if (config.rules['karpathy']?.enabled !== false) {
+          rules.push(new KarpathyRule());
         }
 
         // Add custom rules from plugins

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -15,6 +15,7 @@ import { ImportSyntaxRule } from '../../rules/ImportSyntaxRule.js';
 import { FileLocationRule } from '../../rules/FileLocationRule.js';
 import { ImportResolutionRule } from '../../rules/ImportResolutionRule.js';
 import { ContentAppropriatenessRule } from '../../rules/ContentAppropriatenessRule.js';
+import { KarpathyRule } from '../../rules/KarpathyRule.js';
 import { MonorepoHierarchyRule } from '../../rules/MonorepoHierarchyRule.js';
 import { CommandSafetyRule } from '../../rules/CommandSafetyRule.js';
 import { SkillStructureRule } from '../../rules/SkillStructureRule.js';
@@ -102,6 +103,9 @@ function createRules(config: CclintConfig): Rule[] {
   if (config.rules['hook-configuration']?.enabled !== false) {
     const hookOptions = config.rules['hook-configuration']?.options ?? {};
     rules.push(new HookConfigurationRule(hookOptions));
+  }
+  if (config.rules['karpathy']?.enabled !== false) {
+    rules.push(new KarpathyRule());
   }
 
   return rules;

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,9 @@ export { SkillStructureRule } from './rules/SkillStructureRule.js';
 export { SubagentStructureRule } from './rules/SubagentStructureRule.js';
 export { HookConfigurationRule } from './rules/HookConfigurationRule.js';
 
+// Opinionated recommendations (Karpathy-inspired, INFO severity)
+export { KarpathyRule } from './rules/KarpathyRule.js';
+
 // Deprecated rules (use alternatives)
 /** @deprecated Use ContentOrganizationRule instead - ContentRule is too opinionated with technology-specific checks */
 export { ContentRule } from './rules/ContentRule.js';

--- a/src/infrastructure/RuleMetadata.ts
+++ b/src/infrastructure/RuleMetadata.ts
@@ -476,6 +476,46 @@ export const RULE_METADATA: Record<string, RuleMetadata> = {
     related: ['command-safety', 'subagent-structure'],
     references: ['https://docs.anthropic.com/en/docs/claude-code/hooks'],
   },
+
+  karpathy: {
+    id: 'karpathy',
+    name: 'Karpathy Recommendations',
+    description:
+      'Opinionated CLAUDE.md style advisories: minimal, high-signal, ' +
+      'literal, example-driven context',
+    rationale:
+      'Inspired by Andrej Karpathy’s commentary on writing for LLMs and ' +
+      '"context engineering": you program the model in English, so the ' +
+      'context window should be minimal and high signal-to-noise, ' +
+      'instructions should be literal (hedging invites drift), and rules ' +
+      'are best shown with concrete examples (few-shot beats zero-shot). ' +
+      'Opinionated heuristics, not an official standard — all findings ' +
+      'are INFO.',
+    fixable: false,
+    defaultSeverity: 'info',
+    badExamples: [
+      {
+        code: '- Please try to keep functions small where appropriate. Thank you!',
+        explanation:
+          'Hedging ("try to", "where appropriate") and politeness ' +
+          '("Please", "Thank you") dilute a literal instruction and burn ' +
+          'context tokens.',
+      },
+    ],
+    goodExamples: [
+      {
+        code: '- Keep functions under 40 lines.\n\n```go\nfunc Add(a, b int) int { return a + b }\n```',
+        explanation:
+          'Direct imperative rule plus a concrete example — literal and ' +
+          'few-shot.',
+      },
+    ],
+    related: ['content-appropriateness', 'content-organization'],
+    references: [
+      'https://karpathy.ai/',
+      'https://x.com/karpathy/status/1937902205765607626',
+    ],
+  },
 };
 
 /**

--- a/src/infrastructure/RuleRegistry.ts
+++ b/src/infrastructure/RuleRegistry.ts
@@ -139,6 +139,7 @@ export class RuleRegistry {
       'SkillStructureRule',
       'SubagentStructureRule',
       'HookConfigurationRule',
+      'KarpathyRule',
     ]);
 
     const totalRules = this.rules.size;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,7 @@ import { CommandSafetyRule } from '../rules/CommandSafetyRule.js';
 import { SkillStructureRule } from '../rules/SkillStructureRule.js';
 import { SubagentStructureRule } from '../rules/SubagentStructureRule.js';
 import { HookConfigurationRule } from '../rules/HookConfigurationRule.js';
+import { KarpathyRule } from '../rules/KarpathyRule.js';
 import {
   RULE_METADATA,
   getAllRuleIds,
@@ -41,6 +42,7 @@ function buildEngine(): RulesEngine {
     new SkillStructureRule(),
     new SubagentStructureRule(),
     new HookConfigurationRule(),
+    new KarpathyRule(),
   ]);
 }
 

--- a/src/rules/KarpathyRule.ts
+++ b/src/rules/KarpathyRule.ts
@@ -1,0 +1,293 @@
+import type { Rule } from '../domain/Rule.js';
+import { ContextFile } from '../domain/ContextFile.js';
+import { Violation } from '../domain/Violation.js';
+import { Location } from '../domain/Location.js';
+import { Severity } from '../domain/Severity.js';
+
+/**
+ * KarpathyRule — opinionated CLAUDE.md quality advisories.
+ *
+ * Heuristics inspired by Andrej Karpathy's public commentary on writing for
+ * LLMs and "context engineering": you program the model in English, so the
+ * context window should be minimal, high signal-to-noise, literal, and
+ * example-driven. This is a curated, opinionated ruleset — not an official
+ * standard — and every finding is INFO severity (a recommendation, not a
+ * failure).
+ *
+ * Checks:
+ *  1. Hedging language ("try to", "where appropriate") that makes an
+ *     instruction non-literal — the model follows instructions literally, so
+ *     ambiguity invites drift.
+ *  2. Filler / politeness ("please", "thank you", "you are a helpful
+ *     assistant") that spends context tokens without adding signal.
+ *  3. Show, don't tell — guideline sections that list many rules but include
+ *     no concrete example (few-shot beats zero-shot).
+ *  4. Signal-to-noise — overly long prose paragraphs; prefer tight,
+ *     skimmable lines or bullets.
+ *
+ * Scope: CLAUDE.md files only. Code fences are excluded from prose checks.
+ */
+export class KarpathyRule implements Rule {
+  public readonly id = 'karpathy';
+  public readonly description =
+    'Opinionated CLAUDE.md recommendations inspired by Karpathy: minimal, ' +
+    'high-signal, literal, example-driven context';
+
+  private static readonly HEDGING_PHRASES = [
+    'try to',
+    'where appropriate',
+    'as appropriate',
+    'where possible',
+    'when possible',
+    'if possible',
+    'as needed',
+    'as necessary',
+    'generally',
+    'usually',
+    'typically',
+    'ideally',
+    'more or less',
+    'and so on',
+  ];
+
+  private static readonly FILLER_PHRASES = [
+    'please',
+    'kindly',
+    'thank you',
+    'feel free to',
+    'it is important to note',
+    'it should be noted',
+    'as a reminder',
+    'needless to say',
+    'you are a helpful assistant',
+    'as an ai language model',
+  ];
+
+  private static readonly GUIDELINE_WORDS = [
+    'convention',
+    'guideline',
+    'rule',
+    'standard',
+    'style',
+    'instruction',
+    'workflow',
+    'practice',
+    'principle',
+  ];
+
+  private static readonly MAX_PARAGRAPH_WORDS = 80;
+  private static readonly MAX_PARAGRAPH_CHARS = 600;
+
+  public lint(file: ContextFile): Violation[] {
+    if (!KarpathyRule.isClaudeMd(file.path)) {
+      return [];
+    }
+
+    const lines = file.lines;
+    const inCode = KarpathyRule.markCodeFences(lines);
+
+    return [
+      ...this.checkPhrases(
+        lines,
+        inCode,
+        KarpathyRule.HEDGING_PHRASES,
+        phrase =>
+          `Hedging phrase "${phrase}" weakens a literal instruction. ` +
+          `State the rule directly so the model follows it deterministically.`
+      ),
+      ...this.checkPhrases(
+        lines,
+        inCode,
+        KarpathyRule.FILLER_PHRASES,
+        phrase =>
+          `Filler/politeness "${phrase}" spends context without signal. ` +
+          `Drop it — CLAUDE.md is instructions for a model, not prose for a person.`
+      ),
+      ...this.checkExamples(lines, inCode),
+      ...this.checkParagraphs(lines, inCode),
+    ];
+  }
+
+  private static isClaudeMd(path: string): boolean {
+    return /(^|[/\\])CLAUDE\.md$/i.test(path);
+  }
+
+  /** Returns a boolean per line: true when the line sits inside a ``` fence. */
+  private static markCodeFences(lines: string[]): boolean[] {
+    const inCode: boolean[] = lines.map(() => false);
+    let open = false;
+    for (let i = 0; i < lines.length; i++) {
+      const isFence = /^\s*```/.test(lines[i] ?? '');
+      if (isFence) {
+        // The fence line itself is treated as code so it is never prose.
+        inCode[i] = true;
+        open = !open;
+        continue;
+      }
+      inCode[i] = open;
+    }
+    return inCode;
+  }
+
+  private checkPhrases(
+    lines: string[],
+    inCode: boolean[],
+    phrases: string[],
+    message: (phrase: string) => string
+  ): Violation[] {
+    const violations: Violation[] = [];
+    const seen = new Set<string>();
+
+    for (let i = 0; i < lines.length; i++) {
+      if (inCode[i]) continue;
+      const lower = (lines[i] ?? '').toLowerCase();
+      for (const phrase of phrases) {
+        if (seen.has(phrase)) continue;
+        if (KarpathyRule.containsPhrase(lower, phrase)) {
+          seen.add(phrase);
+          violations.push(
+            new Violation(
+              this.id,
+              message(phrase),
+              Severity.INFO,
+              new Location(i + 1, 1)
+            )
+          );
+        }
+      }
+    }
+    return violations;
+  }
+
+  private static containsPhrase(
+    haystackLower: string,
+    phrase: string
+  ): boolean {
+    const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`\\b${escaped}\\b`, 'i').test(haystackLower);
+  }
+
+  /**
+   * Flag guideline-style sections (Conventions, Guidelines, Rules, …) that
+   * enumerate several rules but show no concrete example — show, don't tell.
+   */
+  private checkExamples(lines: string[], inCode: boolean[]): Violation[] {
+    const violations: Violation[] = [];
+    const headings = KarpathyRule.collectSections(lines);
+
+    for (const section of headings) {
+      const titleLower = section.title.toLowerCase();
+      const isGuideline = KarpathyRule.GUIDELINE_WORDS.some(w =>
+        new RegExp(`\\b${w}`, 'i').test(titleLower)
+      );
+      if (!isGuideline) continue;
+
+      let bullets = 0;
+      let hasCode = false;
+      for (let i = section.bodyStart; i < section.bodyEnd; i++) {
+        if (inCode[i]) {
+          hasCode = true;
+          continue;
+        }
+        if (/^\s*([-*]|\d+\.)\s+/.test(lines[i] ?? '')) bullets++;
+      }
+
+      if (bullets >= 4 && !hasCode) {
+        violations.push(
+          new Violation(
+            this.id,
+            `Section "${section.title}" lists ${bullets} rules but shows no ` +
+              `example. Add a concrete example (show, don't tell) — few-shot ` +
+              `context steers the model better than abstract rules.`,
+            Severity.INFO,
+            new Location(section.headingLine, 1)
+          )
+        );
+      }
+    }
+    return violations;
+  }
+
+  private static collectSections(lines: string[]): Array<{
+    title: string;
+    headingLine: number; // 1-based
+    bodyStart: number; // 0-based inclusive
+    bodyEnd: number; // 0-based exclusive
+  }> {
+    const sections: Array<{
+      title: string;
+      headingLine: number;
+      bodyStart: number;
+      bodyEnd: number;
+    }> = [];
+    const headingIdx: Array<{ idx: number; title: string }> = [];
+    const inCode = KarpathyRule.markCodeFences(lines);
+
+    for (let i = 0; i < lines.length; i++) {
+      if (inCode[i]) continue;
+      const m = /^#{1,6}\s+(.*)$/.exec(lines[i] ?? '');
+      if (m) headingIdx.push({ idx: i, title: (m[1] ?? '').trim() });
+    }
+
+    for (let h = 0; h < headingIdx.length; h++) {
+      const cur = headingIdx[h];
+      if (!cur) continue;
+      const next = headingIdx[h + 1];
+      const end = next ? next.idx : lines.length;
+      sections.push({
+        title: cur.title,
+        headingLine: cur.idx + 1,
+        bodyStart: cur.idx + 1,
+        bodyEnd: end,
+      });
+    }
+    return sections;
+  }
+
+  /** Flag prose paragraphs that are too long to skim. */
+  private checkParagraphs(lines: string[], inCode: boolean[]): Violation[] {
+    const violations: Violation[] = [];
+    let buffer: string[] = [];
+    let startLine = 0;
+
+    const flush = (): void => {
+      if (buffer.length === 0) return;
+      const text = buffer.join(' ').trim();
+      const words = text.split(/\s+/).filter(Boolean).length;
+      if (
+        words > KarpathyRule.MAX_PARAGRAPH_WORDS ||
+        text.length > KarpathyRule.MAX_PARAGRAPH_CHARS
+      ) {
+        violations.push(
+          new Violation(
+            this.id,
+            `Paragraph is ${words} words. Tighten to high-signal lines or ` +
+              `bullets — dense prose buries the instruction.`,
+            Severity.INFO,
+            new Location(startLine, 1)
+          )
+        );
+      }
+      buffer = [];
+    };
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? '';
+      const isProse =
+        !inCode[i] &&
+        line.trim() !== '' &&
+        !/^#{1,6}\s+/.test(line) &&
+        !/^\s*([-*]|\d+\.)\s+/.test(line) &&
+        !/^\s*>/.test(line) &&
+        !/^\s*\|/.test(line);
+      if (isProse) {
+        if (buffer.length === 0) startLine = i + 1;
+        buffer.push(line.trim());
+      } else {
+        flush();
+      }
+    }
+    flush();
+    return violations;
+  }
+}

--- a/tests/unit/rules/KarpathyRule.test.ts
+++ b/tests/unit/rules/KarpathyRule.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { KarpathyRule } from '../../../src/rules/KarpathyRule.js';
+import { ContextFile } from '../../../src/domain/ContextFile.js';
+import { Severity } from '../../../src/domain/Severity.js';
+
+function claude(content: string): ContextFile {
+  return new ContextFile('/repo/CLAUDE.md', content);
+}
+
+describe('KarpathyRule', () => {
+  describe('rule identity', () => {
+    it('has id karpathy', () => {
+      expect(new KarpathyRule().id).toBe('karpathy');
+    });
+    it('has a description', () => {
+      expect(new KarpathyRule().description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('scope', () => {
+    it('only lints CLAUDE.md files', () => {
+      const rule = new KarpathyRule();
+      const other = new ContextFile(
+        '/repo/README.md',
+        'Please try to write good code, thank you.'
+      );
+      expect(rule.lint(other)).toHaveLength(0);
+    });
+  });
+
+  describe('hedging language', () => {
+    it('flags hedging phrases that undermine literal instructions', () => {
+      const v = new KarpathyRule().lint(
+        claude('# Title\n\n- Try to keep functions small where appropriate.')
+      );
+      const hedge = v.find(x => x.message.toLowerCase().includes('hedg'));
+      expect(hedge).toBeDefined();
+      expect(hedge?.severity).toBe(Severity.INFO);
+    });
+
+    it('deduplicates the same hedging phrase to one finding', () => {
+      const v = new KarpathyRule().lint(
+        claude('# T\n\n- Try to do X.\n- Try to do Y.\n- Try to do Z.')
+      );
+      const tryToHits = v.filter(x =>
+        x.message.toLowerCase().includes('try to')
+      );
+      expect(tryToHits).toHaveLength(1);
+    });
+  });
+
+  describe('filler and politeness', () => {
+    it('flags politeness and filler that waste context', () => {
+      const v = new KarpathyRule().lint(
+        claude('# T\n\nPlease run the tests. Thank you.')
+      );
+      expect(v.some(x => x.message.toLowerCase().includes('filler'))).toBe(
+        true
+      );
+    });
+
+    it('flags "you are a helpful assistant" framing', () => {
+      const v = new KarpathyRule().lint(
+        claude('# T\n\nYou are a helpful assistant that writes Go.')
+      );
+      expect(v.some(x => /helpful assistant/i.test(x.message))).toBe(true);
+    });
+  });
+
+  describe('show, do not tell', () => {
+    it('flags a guideline section with many rules but no example', () => {
+      const v = new KarpathyRule().lint(
+        claude(
+          [
+            '# Project',
+            '',
+            '## Conventions',
+            '',
+            '- Use tabs for indentation',
+            '- Name tests Test_Subject',
+            '- Keep functions under 40 lines',
+            '- Return errors, do not panic',
+            '',
+          ].join('\n')
+        )
+      );
+      expect(v.some(x => x.message.toLowerCase().includes('example'))).toBe(
+        true
+      );
+    });
+
+    it('does not flag a guideline section that includes a code example', () => {
+      const v = new KarpathyRule().lint(
+        claude(
+          [
+            '# Project',
+            '',
+            '## Conventions',
+            '',
+            '- Use table-driven tests',
+            '- Name tests Test_Subject',
+            '- Keep functions small',
+            '- Return errors, do not panic',
+            '',
+            '```go',
+            'func Test_Add(t *testing.T) {}',
+            '```',
+            '',
+          ].join('\n')
+        )
+      );
+      expect(v.some(x => x.message.toLowerCase().includes('example'))).toBe(
+        false
+      );
+    });
+  });
+
+  describe('signal-to-noise', () => {
+    it('flags an overly long prose paragraph', () => {
+      const longPara = 'This sentence exists only to add length. '.repeat(25);
+      const v = new KarpathyRule().lint(claude(`# T\n\n${longPara}`));
+      expect(v.some(x => x.message.toLowerCase().includes('paragraph'))).toBe(
+        true
+      );
+    });
+
+    it('does not flag code blocks as long paragraphs', () => {
+      const longCode =
+        '```\n' + 'x := 1 // padding padding padding\n'.repeat(25) + '```';
+      const v = new KarpathyRule().lint(claude(`# T\n\n${longCode}`));
+      expect(v.some(x => x.message.toLowerCase().includes('paragraph'))).toBe(
+        false
+      );
+    });
+  });
+
+  describe('clean file', () => {
+    it('returns no violations for a tight, concrete CLAUDE.md', () => {
+      const v = new KarpathyRule().lint(
+        claude(
+          [
+            '# nomid',
+            '',
+            '## Commands',
+            '',
+            '```bash',
+            'make test   # go test ./...',
+            'make build  # builds bin/nomid',
+            '```',
+            '',
+            '## Conventions',
+            '',
+            '- Module path: github.com/x/y',
+            '- New tools register in tools.Registry',
+            '',
+            '```go',
+            'reg.Register(myTool)',
+            '```',
+            '',
+          ].join('\n')
+        )
+      );
+      expect(v).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
Adds a **`karpathy`** rule (INFO severity, default-on) with heuristics inspired by Andrej Karpathy's commentary on writing for LLMs / context engineering — minimal, high signal-to-noise, literal, example-driven context. Opinionated heuristics, not an official standard; never fails CI.

**Checks** (CLAUDE.md only, code-fence aware):
- Hedging language (`try to`, `where appropriate`) that breaks literal instruction-following
- Filler / politeness (`please`, `thank you`, `you are a helpful assistant`) that spends context without signal
- Guideline sections that list many rules but show no example (show, don't tell)
- Overly long prose paragraphs

Wired into the enhanced lint CLI, MCP server, watch mode, rule metadata (`explain`), registry, and public exports; documented in README (drift gate satisfied). 12 new unit tests; full suite (681) green, typecheck + lint clean.