### PR TITLE
fix(release): sync version refs to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-06-03
+
+### ✨ Features
+
+- **New `karpathy` rule** — opinionated, INFO-severity CLAUDE.md recommendations inspired by Andrej Karpathy's LLM / context-engineering principles (minimal, high signal-to-noise, literal, example-driven). Flags hedging language, filler/politeness, guideline sections without examples (show, don't tell), and overly long prose paragraphs. CLAUDE.md-scoped, code-fence-aware, default-on, never fails CI. Wired into the lint CLI, MCP server, watch mode, `explain`, registry, and public exports.
+
 ## [0.14.0] - 2026-05-09
 
 ### 🛠️ Quality Hardening Release

--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ Add automated linting to your CI/CD pipeline:
 
 ```yaml
 - name: Lint CLAUDE.md
-  uses: felixgeelhaar/cclint@v0.14.0
+  uses: felixgeelhaar/cclint@v0.15.0
   with:
     files: 'CLAUDE.md'
     format: 'text'

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,7 @@ const program = new Command();
 program
   .name('cclint')
   .description('A linter for CLAUDE.md context files')
-  .version('0.14.0');
+  .version('0.15.0');
 
 program.addCommand(lintEnhancedCommand);
 program.addCommand(watchCommand);


### PR DESCRIPTION
0.15.0 release failed the version-sync gate (CLI .version(), CHANGELOG, README action snippet still 0.14.0). Bumps all three + adds the 0.15.0 CHANGELOG entry. Re-tag after merge.