### PR TITLE
chore(release): 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-07-04
+
+### 🔒 Security
+
+- **`path-security`** — path-containment now rejects sibling-prefix escapes: a base of `/project` no longer accepts `/project-evil/...` (previously a `startsWith` check let a sibling directory sharing the base's prefix through). Containment is checked on a path-separator boundary.
+- **`GitDiffProvider`** — git is now invoked via `execFileSync` with argument arrays instead of a shell string, removing a command-injection surface when a branch/ref name reaches the diff commands.
+
+### 🐛 Fixed (false positives)
+
+- **`structure`** — a missing section is now a **warning** ("recommended"), not an error ("required"), so a lean CLAUDE.md no longer fails CI on structure alone.
+- **`import-resolution`** — no longer flags `@`-mentions and other non-import `@` strings; an import is recognized only at a word boundary with a path-like target.
+- **`format`** (`--fix`) — is now fenced-code-aware: it no longer rewrites headers, blank lines, list markers, or trailing whitespace **inside** code blocks, so shebangs, YAML, and formatted snippets survive a fix.
+- **`hook-configuration`** — rewritten to Claude Code's real hooks schema (a top-level `hooks` object keyed by actual events: `PreToolUse`, `SessionStart`, …). It now validates real `settings.json` and catches dangerous hook commands (e.g. `curl … | sh`) that the previous fictional-schema version silently skipped.
+
+### 🔧 Changed
+
+- Per-rule **severity overrides** from config are now actually applied to a rule's emitted violations.
+- Removed the dead `PluginSandbox` in favor of an honest, documented trusted-only plugin posture (plugins run in-process, trusted like any npm dependency).
+
 ## [0.15.0] - 2026-06-03
 
 ### ✨ Features

--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ Add automated linting to your CI/CD pipeline:
 
 ```yaml
 - name: Lint CLAUDE.md
-  uses: felixgeelhaar/cclint@v0.15.0
+  uses: felixgeelhaar/cclint@v0.15.1
   with:
     files: 'CLAUDE.md'
     format: 'text'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felixgeelhaar/cclint",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felixgeelhaar/cclint",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felixgeelhaar/cclint",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Catch CLAUDE.md drift before Claude misbehaves. Lints CLAUDE.md, skills, subagents, and hooks for Claude Code projects.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,7 @@ const program = new Command();
 program
   .name('cclint')
   .description('A linter for CLAUDE.md context files')
-  .version('0.15.0');
+  .version('0.15.1');
 
 program.addCommand(lintEnhancedCommand);
 program.addCommand(watchCommand);


### PR DESCRIPTION
Patch release shipping the review-batch product fixes merged in #34 to npm users (currently on main but unpublished at v0.15.0).

### Security
- `path-security`: reject sibling-prefix path escapes (`/project` no longer accepts `/project-evil/…`); containment checked on a separator boundary.
- `GitDiffProvider`: git invoked via `execFileSync` arg-arrays (no shell) — removes a command-injection surface from branch/ref names.

### Fixed (false positives)
- `structure`: missing section → warning ("recommended"), not error.
- `import-resolution`: no longer flags `@`-mentions / non-import `@` strings.
- `format --fix`: fenced-code-aware — won't rewrite inside code blocks (shebangs/YAML/snippets survive).
- `hook-configuration`: rewritten to Claude Code's real hooks schema; validates real `settings.json` and catches dangerous commands (`curl | sh`) the old fictional schema missed.

### Changed
- Per-rule severity overrides now actually applied.
- Removed dead `PluginSandbox` (honest trusted-only plugin posture).

Version bumped in package.json, package-lock, `src/cli/index.ts`, README action ref, CHANGELOG. Tag `v0.15.1` after merge triggers the npm publish + GitHub Release.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ