### PR TITLE
docs: bring docs current for 0.16.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,28 @@ The project uses a **Domain-Driven Design** approach with hexagonal architecture
 ### Architecture Layers
 
 ```
-CLI Adapter ──┐
-              ├──► Core Linting Engine (npm package)
-VS Code Ext ──┘     ├── Rules Engine (aggregates violations)
-                    ├── Individual Rules (implement Rule interface)
-                    └── File System I/O (reads CLAUDE.md, .gitignore)
+CLI  (cclint)      ──┐
+MCP  (cclint-mcp)  ──┼──► Core Linting Engine (npm package)
+LSP  (cclint-lsp)  ──┤     ├── Rules Engine (aggregates violations)
+GitHub Action      ──┘     ├── createRules(config) factory + rule descriptors
+                           ├── Individual Rules (implement Rule interface)
+                           └── File System I/O (reads CLAUDE.md, config files)
 ```
+
+All four entry points build their rule set from the **single** `createRules(config)`
+factory (`src/rules/registry/`), driven by canonical `RULE_DESCRIPTORS` — one
+source of truth for each rule's id, default-enabled flag, and metadata — so every
+entry point runs an identical, in-lock-step rule set.
+
+### Bins
+
+- `cclint` — CLI (`src/cli/index.ts`). `cclint lint <file>` lints one file;
+  `cclint lint <dir>` (e.g. `cclint lint .`) discovers and lints a whole
+  project tree. Other commands: `watch`, `init`, `install`/`uninstall`,
+  `explain`, `mcp`, `why`.
+- `cclint-mcp` — MCP server (`src/mcp/`) for MCP-compatible clients.
+- `cclint-lsp` — Language Server (`src/lsp/`); run `cclint-lsp --stdio` for
+  real-time diagnostics and quick-fix code actions in any LSP editor.
 
 ## Technology Stack
 
@@ -89,12 +105,15 @@ Required CI jobs:
 The project contains:
 
 - `src/` - TypeScript source code
-  - `domain/` - Core domain model (Rule, Violation, ContextFile, etc.)
-  - `rules/` - Individual linting rules
-  - `infrastructure/` - Infrastructure adapters (CLI, file I/O)
-  - `cli/` - CLI commands
+  - `domain/` - Core domain model (Rule, Violation, ContextFile, RulesEngine, etc.)
+  - `rules/` - Individual linting rules (19 built-in rules)
+    - `rules/registry/` - `createRules` factory + `RULE_DESCRIPTORS`/`RULE_METADATA` (single source of truth)
+  - `infrastructure/` - Adapters (FileReader, FileDiscovery, ConfigLoader, PluginLoader, path/DoS validators)
+  - `cli/` - CLI commands and output formatters
+  - `mcp/` - MCP server (`cclint-mcp`)
+  - `lsp/` - Language Server (`cclint-lsp`)
   - `action/` - GitHub Action implementation
-- `tests/` - Vitest test files
+- `tests/` - Vitest test files (incl. drift + version-sync regression gates)
 - `docs/` - Documentation and ADRs
 
 ## Key Development Principles

--- a/README.md
+++ b/README.md
@@ -62,6 +62,38 @@ cclint lint CLAUDE.md --format sarif > cclint.sarif
 cclint lint CLAUDE.md --max-size 5000
 ```
 
+### Project-wide Linting
+
+Point `cclint lint` at a directory (`.` for the whole project) and it discovers
+and lints every Claude Code config file under that tree, routing each file to
+the rules that apply to it:
+
+```bash
+# Lint the whole project
+cclint lint .
+
+# Lint a specific directory
+cclint lint packages/api
+
+# Aggregate results as JSON or SARIF
+cclint lint . --format json
+cclint lint . --format sarif > cclint.sarif
+```
+
+Discovery walks the directory (skipping `node_modules`, `.git`, `dist`,
+`coverage`, `.stryker-tmp`) and picks up:
+
+- `CLAUDE.md` files (including nested ones)
+- `.claude/skills/**/*.md`, `.claude/agents/**/*.md`, `.claude/output-styles/**/*.md`
+- `.claude/settings.json` and `.claude/settings.local.json`
+- `.mcp.json` (including nested)
+- `.claude-plugin/plugin.json` and `marketplace.json`
+
+Each file is linted with only the rules that apply to its kind (structure rules
+for `CLAUDE.md`, hook rules for `settings.json`, `mcp-config` for `.mcp.json`,
+and so on). Results are aggregated across all files and the run exits non-zero if
+any file has an error-severity violation.
+
 ### Example Output
 
 ```
@@ -389,13 +421,20 @@ Without `--ai`, prints the rule rationale and good example. With `--ai`, sends t
 ### Command Line Options
 
 ```bash
-cclint lint [options] <file>
+cclint lint [options] <path>          # <path> may be a file or a directory
 
 Options:
   -f, --format <format>   Output format (text, json, sarif) (default: "text")
   --max-size <size>       Maximum file size in characters (default: "10000")
   -c, --config <path>     Path to configuration file
   --fix                   Automatically fix problems where possible
+  -i, --interactive       Interactively fix problems one at a time
+  --diff                  Only show violations on changed lines
+  --diff-ref <ref>        Git ref to compare against (default: "HEAD")
+  --plain                 Plain text output (no emoji) for CI logs / screen readers
+  --summary               Group violations by rule with counts
+  --allow-plugins         Load custom rule plugins declared in project config
+                          (opt-in; also set via CCLINT_ALLOW_PLUGINS=1)
   -h, --help              Display help for command
 
 cclint install [options]
@@ -487,7 +526,7 @@ npm run dev           # Run development version
 
 CC Linter follows **Test-Driven Development (TDD)**:
 
-- ✅ **371 tests** with comprehensive coverage
+- ✅ **980 tests** with comprehensive coverage
 - 🚀 **Vitest** for ultra-fast test execution
 - 🎯 **Unit tests** for domain logic
 - 🔗 **Integration tests** for CLI functionality
@@ -706,11 +745,30 @@ export default {
 - ⚙️ **Configurable**: Enable/disable and configure custom rules
 - 📊 **Multiple Severities**: Error, warning, or info levels
 
+> **🔒 Plugins are opt-in.** A config-declared plugin runs arbitrary code
+> in-process, so cclint will **not** load the plugins listed in a project's
+> `.cclintrc.json`/`package.json` unless you explicitly trust them by passing
+> `--allow-plugins` (or setting `CCLINT_ALLOW_PLUGINS=1`). Without that gate the
+> plugins are skipped — never imported — and cclint tells you how to enable
+> them. This keeps linting an untrusted repository safe by default.
+
+```bash
+# Trust and load this project's declared plugins
+cclint lint CLAUDE.md --allow-plugins
+
+# Equivalent via environment variable
+CCLINT_ALLOW_PLUGINS=1 cclint lint .
+```
+
 📚 [View Example Custom Rules](examples/custom-rules/)
 
 ## 🔮 Roadmap
 
-- [ ] **VS Code Extension** - Real-time linting in your editor
+- [ ] **VS Code Extension** - First-party editor client (a generic LSP client works today)
+- [x] **LSP Server** - Real-time diagnostics + quick fixes in any editor (`cclint-lsp`) ✅
+- [x] **Project-wide Linting** - `cclint lint .` across a whole config tree ✅
+- [x] **Config Presets** - `extends: "@cclint/recommended" | "@cclint/strict"` ✅
+- [x] **SARIF Output** - `--format sarif` for GitHub Code Scanning ✅
 - [x] **Custom Rules API** - Plugin system for custom validation logic ✅
 - [x] **Enhanced Auto-fix** - More intelligent fixes and suggestions ✅
 - [x] **Configuration Files** - `.cclintrc.json` for project-specific rules ✅

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,22 +13,53 @@ Transform cclint from a CLI linter into a **full-featured platform** for CLAUDE.
 
 ---
 
-## Release Timeline
+## Current status (as of v0.16.0)
 
-| Version | Theme                         | Target   | Status      |
-| ------- | ----------------------------- | -------- | ----------- |
-| v0.6.0  | 10/10 Anthropic Alignment     | Jan 2025 | ✅ Released |
-| v0.7.0  | Developer Experience          | Q1 2025  | 🚧 Planning |
-| v0.8.0  | Editor Integration (LSP)      | Q1 2025  | 📋 Planned  |
-| v0.9.0  | AI Integration                | Q2 2025  | 📋 Planned  |
-| v0.11.0 | Claude Code Extended Features | Mar 2026 | ✅ Released |
-| v1.0.0  | Full Platform                 | Q2 2025  | 📋 Planned  |
+The developer-experience (v0.7) and editor-integration (v0.8) themes have both
+**shipped**, and several platform-level items have landed early:
+
+- ✅ **Developer experience** — watch mode, `init`, hook installation,
+  interactive fix, `explain`, and diff-aware linting all shipped.
+- ✅ **LSP server** — `cclint-lsp --stdio` delivers real-time diagnostics and
+  quick-fix code actions to any LSP editor (ADR 008). A first-party VS Code
+  extension client is **not yet published** (a generic LSP client works today).
+- ✅ **Project-wide lint** — `cclint lint .` walks a whole config tree and lints
+  each file with the rules that apply to it.
+- ✅ **Config presets** — `extends: "@cclint/recommended" | "@cclint/strict"`.
+- ✅ **New validators** — `secret-detection`, `plugin-manifest`, `mcp-config`,
+  and `output-style` rules.
+- ✅ **SARIF output** — `--format sarif` for GitHub Code Scanning.
+- 🟡 **AI integration** — partially shipped: `cclint why --ai` gives AI fix
+  suggestions. Broader AI features (`suggest`, codebase-aware `analyze`) remain
+  planned.
+
+Remaining themes below (broader AI integration, the v1.0 platform features) are
+still aspirational.
 
 ---
 
-## v0.7.0 - Developer Experience
+## Release Timeline
+
+| Version | Theme                         | Target   | Status         |
+| ------- | ----------------------------- | -------- | -------------- |
+| v0.6.0  | 10/10 Anthropic Alignment     | Jan 2025 | ✅ Released    |
+| v0.7.0  | Developer Experience          | 2026     | ✅ Released    |
+| v0.8.0  | Editor Integration (LSP)      | 2026     | ✅ Released    |
+| v0.9.0  | AI Integration                | —        | 🟡 In progress |
+| v0.11.0 | Claude Code Extended Features | Mar 2026 | ✅ Released    |
+| v0.16.0 | Project-wide lint, LSP, new rules, presets, security | Jul 2026 | ✅ Released    |
+| v1.0.0  | Full Platform                 | TBD      | 📋 Planned     |
+
+---
+
+## v0.7.0 - Developer Experience ✅ Shipped
 
 **Theme**: Make cclint delightful to use in daily development workflows.
+
+> **Status:** all six features below have shipped. Note the delivered CLI spells
+> a couple of commands differently than the sketches here: hook management is
+> `cclint install` / `cclint uninstall` (not `install-hook`), and diff-aware
+> linting is `cclint lint --diff [--diff-ref <ref>]`.
 
 ### Features
 
@@ -176,9 +207,15 @@ cclint lint --diff abc123
 
 ---
 
-## v0.8.0 - Editor Integration (LSP)
+## v0.8.0 - Editor Integration (LSP) ✅ Shipped (v0.16.0)
 
 **Theme**: Real-time linting in any editor via Language Server Protocol.
+
+> **Status:** the LSP server shipped in v0.16.0 as the `cclint-lsp` bin (run
+> `cclint-lsp --stdio`), providing live diagnostics on open/change/save and
+> quick-fix code actions, config-aware via discovered `.cclintrc.json`/presets
+> (ADR 008). A first-party VS Code extension and a dedicated Neovim plugin are
+> **not yet published** — any editor with a generic LSP client works today.
 
 ### Features
 
@@ -252,9 +289,14 @@ Native Neovim integration.
 
 ---
 
-## v0.9.0 - AI Integration
+## v0.9.0 - AI Integration 🟡 Partially shipped
 
 **Theme**: Leverage Claude to provide intelligent suggestions and automation.
+
+> **Status:** partially delivered. `cclint why --ai` sends an offending line and
+> rule context to Claude and prints a focused fix suggestion (opt-in, needs
+> `ANTHROPIC_API_KEY`). The broader `suggest`/`analyze` commands below are still
+> planned.
 
 ### Features
 
@@ -398,9 +440,14 @@ cclint pack publish
 - `@cclint/monorepo` - Optimized for monorepos
 - `@cclint/library` - For published packages
 
-#### 4. Configuration Presets
+#### 4. Configuration Presets 🟡 Partially shipped
 
 One-line setup for common scenarios.
+
+> **Status:** the `extends` mechanism shipped in v0.16.0 with two built-in
+> presets — `@cclint/recommended` and `@cclint/strict` (array form supported).
+> The language/project-type presets sketched below are still planned. See the
+> [Configuration Guide](./configuration.md#presets-extends).
 
 ```json
 {
@@ -466,7 +513,7 @@ pipelines:
 ### Security Enhancements
 
 - SBOM validation for imports
-- Secret detection in code blocks
+- ✅ Secret detection in code blocks — shipped in v0.16.0 (`secret-detection` rule)
 - Dependency vulnerability checking
 
 ---

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,45 +1,34 @@
-## Claude Code Extended Features (v0.11.0)
+# Backlog
 
-Implemented rules to validate Anthropic's extended Claude Code features:
+Working list of features considered for cclint. Shipped items are kept here for
+a short while as a record, then pruned; see [CHANGELOG.md](../CHANGELOG.md) for
+the authoritative release history.
 
-- `skill-structure`: Validates `.claude/skills/*.md` files
-- `subagent-structure`: Validates `.claude/agents/*.md` files
-- `hook-configuration`: Validates `.claude/settings.json`
+## Open
 
----
+_Nothing queued right now._ New ideas and their rationale live in
+[ROADMAP.md](./ROADMAP.md); the largest remaining item is a first-party VS Code
+extension client (a generic LSP client already works via `cclint-lsp --stdio`).
 
-## Watch Mode Command
+## Shipped
 
-Implement `cclint watch` command that continuously lints CLAUDE.md files on changes. Uses chokidar for cross-platform file watching with debouncing. Supports recursive watching, auto-fix on change, and clear terminal between runs.
-
----
-
-## Init/Scaffold Command
-
-Implement `cclint init` command to generate starter CLAUDE.md files. Includes template system (minimal, typescript, python, go, monorepo, library, api), project type detection from package.json/pyproject.toml/go.mod, and interactive mode with prompts.
-
----
-
-## Pre-commit Hook Installation
-
-Implement `cclint install-hook` and `cclint uninstall-hook` commands. Auto-detect hook manager (husky, lefthook, pre-commit, raw git). Support --fix and --staged options for hook behavior.
-
----
-
-## Interactive Fix Mode
-
-Add --interactive flag to lint command for step-through fix review. Show violation details, current content, and suggested fix. Allow apply/skip/apply-all/quit actions using inquirer prompts.
-
----
-
-## Explain Command
-
-Implement `cclint explain [rule]` command for rule documentation. Add metadata to all rules (description, rationale, examples, options). Support --all to list rules and --category to filter.
-
----
-
-## Diff-Aware Linting
-
-Add --diff flag to lint command to only report violations in changed lines. Use simple-git to get diff hunks. Filter violations by changed line ranges. Support comparing to any git ref.
-
----
+- ✅ **Project-wide lint** (v0.16.0) — `cclint lint .` discovers and lints a whole
+  config tree (`CLAUDE.md`, `.claude/skills|agents|output-styles/**`,
+  `settings*.json`, `.mcp.json`, plugin/marketplace manifests).
+- ✅ **LSP server** (v0.16.0) — `cclint-lsp` provides real-time diagnostics and
+  quick-fix code actions in any LSP editor (ADR 008).
+- ✅ **Config presets** (v0.16.0) — `extends: "@cclint/recommended" | "@cclint/strict"`.
+- ✅ **New validators** (v0.16.0) — `secret-detection`, `plugin-manifest`,
+  `mcp-config`, `output-style`.
+- ✅ **SARIF output** (v0.16.0) — `--format sarif` for GitHub Code Scanning.
+- ✅ **Claude Code Extended Features** (v0.11.0) — `skill-structure`,
+  `subagent-structure`, and `hook-configuration` rules.
+- ✅ **Watch mode** — `cclint watch` continuously lints on change (chokidar,
+  debounced, recursive, auto-fix).
+- ✅ **Init/scaffold** — `cclint init` generates starter CLAUDE.md files with
+  template system and project-type detection.
+- ✅ **Pre-commit hook installation** — `cclint install` / `cclint uninstall`.
+- ✅ **Interactive fix mode** — `cclint lint --interactive` step-through review.
+- ✅ **Explain command** — `cclint explain [rule]` with rule metadata.
+- ✅ **Diff-aware linting** — `cclint lint --diff` (`--diff-ref <ref>`) reports
+  only violations on changed lines.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,6 +298,33 @@ You can also configure cclint in your `package.json`:
 }
 ```
 
+## Plugins (`--allow-plugins`)
+
+A project's configuration may declare custom rule plugins:
+
+```json
+{
+  "plugins": [{ "name": "./my-plugin.js", "enabled": true }]
+}
+```
+
+A config-declared plugin runs **arbitrary code in-process**. To avoid executing
+untrusted code simply by linting a repository, cclint does **not** load these
+plugins by default. They are only loaded when you explicitly opt in:
+
+```bash
+# Load the plugins declared in this project's config
+cclint lint CLAUDE.md --allow-plugins
+
+# Same, via environment variable
+CCLINT_ALLOW_PLUGINS=1 cclint lint .
+```
+
+Without `--allow-plugins` (or `CCLINT_ALLOW_PLUGINS=1`) the declared plugins are
+skipped — never imported — and cclint prints how many were skipped and how to
+enable them. This trust gate is set out-of-band by the operator; the linted
+repository itself cannot flip it.
+
 ## CLI Override
 
 Configuration file settings can be overridden via CLI options:
@@ -311,6 +338,9 @@ cclint lint CLAUDE.md --config ./custom-config.json
 
 # Enable auto-fix regardless of config
 cclint lint CLAUDE.md --fix
+
+# Trust and load config-declared plugins (opt-in)
+cclint lint CLAUDE.md --allow-plugins
 ```
 
 ## Validation


### PR DESCRIPTION
Documentation-consistency pass for the 0.16.0 release. No source logic, version numbers, CHANGELOG, workflows, or `.nox/` touched — every documented flag/command/rule was verified against the code.

## What changed

**README.md**
- Added a **Project-wide Linting** section to Quick Start: `cclint lint .` / linting a directory, with the exact discovery set (CLAUDE.md incl. nested, `.claude/skills|agents|output-styles/**`, `.claude/settings.json` + `settings.local.json`, `.mcp.json`, `.claude-plugin/plugin.json`, `marketplace.json`) and per-file rule routing + aggregation — verified against `lintEnhanced.ts` and `FileDiscovery.ts`.
- Documented the **`--allow-plugins`** flag and **`CCLINT_ALLOW_PLUGINS=1`** env var (verified in `lintEnhanced.ts`) in Command Line Options and in the Custom Rules section, framed as the security trust gate: config-declared plugins are never loaded/executed without it.
- Expanded the CLI options list (`-i`, `--diff`, `--diff-ref`, `--plain`, `--summary`, `--allow-plugins`).
- Refreshed the mini-roadmap (LSP, project-wide lint, presets, SARIF marked done) and corrected the stale test count (371 → 980).
- Confirmed Built-in Rules section is complete for all 19 registry ids (drift test green) and that LSP/MCP/SARIF/presets sections read correctly.

**docs/configuration.md** — added a **Plugins (`--allow-plugins`)** section and a CLI-override example; presets (`extends`) already covered.

**docs/ROADMAP.md** — added a current-status summary; marked the DX (v0.7) and LSP (v0.8) themes shipped; noted AI integration and config presets as partially shipped; updated the release timeline (added the v0.16.0 row); marked secret detection shipped. No fabricated future plans.

**docs/backlog.md** — reconciled with reality: shipped items moved to a Shipped section (all prior backlog entries have shipped), Open section now empty.

**CLAUDE.md** — documented the `cclint`/`cclint-mcp`/`cclint-lsp` bins, `lint .`, the `createRules(config)` factory + `RULE_DESCRIPTORS` single-source-of-truth architecture, and the current `src/` layout (mcp/, lsp/, rules/registry/).

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test -- --run` ✅ 980 passed (67 files) — incl. rule-registry-drift and version-sync gates.

https://claude.ai/code/session_01XsciE5KjxtMrHimxWxBVFS